### PR TITLE
Added price queries, added trades_peg_ratio, flipped price_peg_ratio over to price

### DIFF
--- a/coinbase/cbeth_price.sql
+++ b/coinbase/cbeth_price.sql
@@ -1,0 +1,39 @@
+/* Dune query number  - 3661946 */
+with weth as (
+    select
+        date_trunc('hour', minute) as hr,
+        avg(price) as price
+    from
+        prices.usd
+    where
+        contract_address = 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
+        and minute >= cast(current_timestamp - interval '1' year as timestamp)
+    group by
+        date_trunc('hour', minute)
+)
+,
+token as (
+    select
+        date_trunc('hour', minute) as hr,
+        contract_address,
+        avg(price) as price
+    from
+        prices.usd
+    where
+        contract_address = 0xbe9895146f7af43049ca1c1ae358b0541ea49704
+        and minute >= cast(current_timestamp - interval '1' year as timestamp)
+    group by
+        date_trunc('hour', minute),
+        contract_address
+)
+
+select
+    token.hr,
+    token.contract_address as token_contract_address,
+    'cbETH' as token_name,
+    token.price as price_usd,
+    token.price / weth.price as price_eth
+from
+    token
+inner join weth on
+    token.hr = weth.hr

--- a/coinbase/cbeth_price_peg_ratio.sql
+++ b/coinbase/cbeth_price_peg_ratio.sql
@@ -1,4 +1,4 @@
-/* Dune query number  - 3465286 */
+/* Dune query number  - 3664524 */
 with hours as (
     select
         timestamp as hr,
@@ -28,32 +28,17 @@ peg as (
         and hours.hr < peg.next_hr
 ),
 
-trades as (
-    select
-        date_trunc('hour', trades.t) as hr,
-        sum(trades.token_trade_amount_eth) as token_trade_amount_eth,
-        sum(trades.token_trade_amount) as token_trade_amount,
-        sum(trades.token_trade_amount_eth) / sum(trades.token_trade_amount) as token_price_eth
-    from query_3465242 as trades
-    where trades.t > cast(current_timestamp as timestamp) - interval '1' year
-    group by 1
-),
-
 prices as (
     select
         hours.hr,
-        prices.token_price_eth,
-        prices.token_trade_amount_eth,
-        prices.token_trade_amount
+        prices.token_price_eth
     from hours
     left join
         (select
             hr,
             token_price_eth,
-            token_trade_amount_eth,
-            token_trade_amount,
             lead(hr) over (order by hr) as next_hr
-        from trades) as prices on
+        from query_3661946) as prices on
         hours.hr >= prices.hr
         and hours.hr < prices.next_hr
 )
@@ -65,8 +50,6 @@ select
     avg(prices.token_price_eth)
         over (order by hours.hr rows between 5 preceding and current row)
         as token_price_eth_6hr_ma,
-    prices.token_trade_amount_eth,
-    prices.token_trade_amount,
     peg.token_peg_eth,
     prices.token_price_eth / peg.token_peg_eth as token_price_peg_ratio,
     avg(prices.token_price_eth) over (order by hours.hr rows between 5 preceding and current row)

--- a/coinbase/cbeth_trades_peg_ratio.sql
+++ b/coinbase/cbeth_trades_peg_ratio.sql
@@ -1,0 +1,79 @@
+/* Dune query number  - 3465286 */
+with hours as (
+    select
+        timestamp as hr,
+        date_trunc('day', timestamp) as d
+    from
+        unnest(
+            sequence(
+                date_trunc('hour', cast(current_timestamp as timestamp) - interval '1' year),
+                cast(current_timestamp as timestamp),
+                interval '60' minute
+            )
+        ) as tbl (timestamp)
+),
+
+peg as (
+    select
+        hours.hr,
+        peg.token_peg_eth
+    from hours
+    left join
+        (select
+            date_trunc('hour', t) as hr,
+            token_peg_eth,
+            lead(date_trunc('hour', t)) over (order by date_trunc('hour', t)) as next_hr
+        from query_3465256) as peg on
+        hours.hr >= peg.hr
+        and hours.hr < peg.next_hr
+),
+
+trades as (
+    select
+        date_trunc('hour', trades.t) as hr,
+        sum(trades.token_trade_amount_eth) as token_trade_amount_eth,
+        sum(trades.token_trade_amount) as token_trade_amount,
+        sum(trades.token_trade_amount_eth) / sum(trades.token_trade_amount) as token_price_eth
+    from query_3465242 as trades
+    where trades.t > cast(current_timestamp as timestamp) - interval '1' year
+    group by 1
+),
+
+prices as (
+    select
+        hours.hr,
+        prices.token_price_eth,
+        prices.token_trade_amount_eth,
+        prices.token_trade_amount
+    from hours
+    left join
+        (select
+            hr,
+            token_price_eth,
+            token_trade_amount_eth,
+            token_trade_amount,
+            lead(hr) over (order by hr) as next_hr
+        from trades) as prices on
+        hours.hr >= prices.hr
+        and hours.hr < prices.next_hr
+)
+
+select
+    hours.hr,
+    'cbETH' as token_name,
+    prices.token_price_eth,
+    avg(prices.token_price_eth)
+        over (order by hours.hr rows between 5 preceding and current row)
+        as token_price_eth_6hr_ma,
+    prices.token_trade_amount_eth,
+    prices.token_trade_amount,
+    peg.token_peg_eth,
+    prices.token_price_eth / peg.token_peg_eth as token_price_peg_ratio,
+    avg(prices.token_price_eth) over (order by hours.hr rows between 5 preceding and current row)
+    / peg.token_peg_eth as token_price_peg_ratio_6hr_ma,
+    (prices.token_price_eth / peg.token_peg_eth) - 1 as token_peg_pct_divergence,
+    avg(prices.token_price_eth) over (order by hours.hr rows between 5 preceding and current row) / peg.token_peg_eth
+    - 1 as token_peg_pct_divergence_6hr_ma
+from hours
+left join peg on hours.hr = peg.hr
+left join prices on hours.hr = prices.hr

--- a/lido/steth/steth_peg_no_rebase.sql
+++ b/lido/steth/steth_peg_no_rebase.sql
@@ -1,0 +1,23 @@
+/* Dune query number  - 3621788 */
+select
+    cast(evt_block_number as bigint) as block,
+    evt_block_time as t,
+    date_trunc('day', evt_block_time) as d,
+    posttotalether / cast(posttotalshares as double) as token_peg_eth,
+    0xae7ab96520de3a18e5e111b5eaab095312d7fe84 as token_contract_address,
+    'stETH' as token_name
+from
+    lido_ethereum.steth_evt_tokenrebased
+union all
+select
+    cast(evt_block_number as bigint) as block,
+    evt_block_time as t,
+    date_trunc('day', evt_block_time) as d,
+    posttotalpooledether / cast(totalshares as double) as token_peg_eth,
+    0xae7ab96520de3a18e5e111b5eaab095312d7fe84 as token_contract_address,
+    'stETH' as token_name
+from
+    lido_ethereum.legacyoracle_evt_posttotalshares
+where
+    evt_block_time >= cast('2022-09-01 00:00' as timestamp)
+    and evt_block_time <= cast('2023-05-16 00:00' as timestamp)

--- a/lido/steth/steth_price.sql
+++ b/lido/steth/steth_price.sql
@@ -1,0 +1,40 @@
+/* Dune query number  - 3664583 */
+with weth as (
+    select
+        date_trunc('hour', minute) as hr,
+        avg(price) as price
+    from
+        prices.usd
+    where
+        contract_address = 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
+        and minute >= cast(current_timestamp - interval '1' year as timestamp)
+    group by
+        date_trunc('hour', minute)
+)
+,
+token as (
+    select
+        date_trunc('hour', minute) as hr,
+        contract_address,
+        avg(price) as price
+    from
+        prices.usd
+    where
+        contract_address = 0xae7ab96520de3a18e5e111b5eaab095312d7fe84
+        and minute >= cast(current_timestamp - interval '1' year as timestamp)
+    group by
+        date_trunc('hour', minute),
+        contract_address
+)
+
+select
+    token.hr,
+    token.contract_address as token_contract_address,
+    'stETH' as token_name,
+    token.price as token_price_usd,
+    weth.price as weth_price_usd,
+    token.price / weth.price as token_price_eth
+from
+    token
+inner join weth on
+    token.hr = weth.hr

--- a/lido/steth/steth_price_peg_ratio.sql
+++ b/lido/steth/steth_price_peg_ratio.sql
@@ -1,4 +1,4 @@
-/* Dune query number  - 3480205 */
+/* Dune query number  - 3668358 */
 with hours as (
     select
         timestamp as hr,
@@ -16,37 +16,21 @@ with hours as (
 peg as (
     select
         hours.hr,
-        peg.token_peg_eth
+        1 as token_peg_eth
     from hours
-    cross join (select distinct token_peg_eth from query_3480196) as peg
-),
-
-trades as (
-    select
-        date_trunc('hour', trades.t) as hr,
-        sum(trades.token_trade_amount_eth) as token_trade_amount_eth,
-        sum(trades.token_trade_amount) as token_trade_amount,
-        sum(trades.token_trade_amount_eth) / sum(trades.token_trade_amount) as token_price_eth
-    from query_3480173 as trades
-    where trades.t > cast(current_timestamp as timestamp) - interval '1' year
-    group by 1
 ),
 
 prices as (
     select
         hours.hr,
-        prices.token_price_eth,
-        prices.token_trade_amount_eth,
-        prices.token_trade_amount
+        prices.token_price_eth
     from hours
     left join
         (select
             hr,
             token_price_eth,
-            token_trade_amount_eth,
-            token_trade_amount,
             lead(hr) over (order by hr) as next_hr
-        from trades) as prices on
+        from query_3664583) as prices on
         hours.hr >= prices.hr
         and hours.hr < prices.next_hr
 )
@@ -58,8 +42,6 @@ select
     avg(prices.token_price_eth)
         over (order by hours.hr rows between 5 preceding and current row)
         as token_price_eth_6hr_ma,
-    prices.token_trade_amount_eth,
-    prices.token_trade_amount,
     peg.token_peg_eth,
     prices.token_price_eth / peg.token_peg_eth as token_price_peg_ratio,
     avg(prices.token_price_eth) over (order by hours.hr rows between 5 preceding and current row)

--- a/lido/steth/steth_trades_peg_ratio.sql
+++ b/lido/steth/steth_trades_peg_ratio.sql
@@ -1,4 +1,4 @@
-/* Dune query number  - 3671485 */
+/* Dune query number  - 3480205 */
 with hours as (
     select
         timestamp as hr,
@@ -18,38 +18,48 @@ peg as (
         hours.hr,
         peg.token_peg_eth
     from hours
-    left join
-        (select
-            date_trunc('hour', t) as hr,
-            token_peg_eth,
-            lead(date_trunc('hour', t)) over (order by date_trunc('hour', t)) as next_hr
-        from query_3480099) as peg on
-        hours.hr >= peg.hr
-        and hours.hr < peg.next_hr
+    cross join (select distinct token_peg_eth from query_3480196) as peg
+),
+
+trades as (
+    select
+        date_trunc('hour', trades.t) as hr,
+        sum(trades.token_trade_amount_eth) as token_trade_amount_eth,
+        sum(trades.token_trade_amount) as token_trade_amount,
+        sum(trades.token_trade_amount_eth) / sum(trades.token_trade_amount) as token_price_eth
+    from query_3480173 as trades
+    where trades.t > cast(current_timestamp as timestamp) - interval '1' year
+    group by 1
 ),
 
 prices as (
     select
         hours.hr,
-        prices.token_price_eth
+        prices.token_price_eth,
+        prices.token_trade_amount_eth,
+        prices.token_trade_amount
     from hours
     left join
         (select
             hr,
             token_price_eth,
+            token_trade_amount_eth,
+            token_trade_amount,
             lead(hr) over (order by hr) as next_hr
-        from query_3664567) as prices on
+        from trades) as prices on
         hours.hr >= prices.hr
         and hours.hr < prices.next_hr
 )
 
 select
     hours.hr,
-    'rETH' as token_name,
+    'stETH' as token_name,
     prices.token_price_eth,
     avg(prices.token_price_eth)
         over (order by hours.hr rows between 5 preceding and current row)
         as token_price_eth_6hr_ma,
+    prices.token_trade_amount_eth,
+    prices.token_trade_amount,
     peg.token_peg_eth,
     prices.token_price_eth / peg.token_peg_eth as token_price_peg_ratio,
     avg(prices.token_price_eth) over (order by hours.hr rows between 5 preceding and current row)

--- a/lido/wsteth/wsteth_price.sql
+++ b/lido/wsteth/wsteth_price.sql
@@ -1,0 +1,40 @@
+/* Dune query number  - 3661977 */
+with weth as (
+    select
+        date_trunc('hour', minute) as hr,
+        avg(price) as price
+    from
+        prices.usd
+    where
+        contract_address = 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
+        and minute >= cast(current_timestamp - interval '1' year as timestamp)
+    group by
+        date_trunc('hour', minute)
+)
+,
+token as (
+    select
+        date_trunc('hour', minute) as hr,
+        contract_address,
+        avg(price) as price
+    from
+        prices.usd
+    where
+        contract_address = 0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0
+        and minute >= cast(current_timestamp - interval '1' year as timestamp)
+    group by
+        date_trunc('hour', minute),
+        contract_address
+)
+
+select
+    token.hr,
+    token.contract_address as token_contract_address,
+    'wstETH' as token_name,
+    token.price as token_price_usd,
+    weth.price as weth_price_usd,
+    token.price / weth.price as token_price_eth
+from
+    token
+inner join weth on
+    token.hr = weth.hr

--- a/lido/wsteth/wsteth_price_peg_ratio.sql
+++ b/lido/wsteth/wsteth_price_peg_ratio.sql
@@ -1,4 +1,4 @@
-/* Dune query number  - 3642007 */
+/* Dune query number  - 3656961 */
 with hours as (
     select
         timestamp as hr,
@@ -28,33 +28,17 @@ peg as (
         and hours.hr < peg.next_hr
 ),
 
-
-trades as (
-    select
-        date_trunc('hour', trades.t) as hr,
-        sum(trades.token_trade_amount_eth) as token_trade_amount_eth,
-        sum(trades.token_trade_amount) as token_trade_amount,
-        sum(trades.token_trade_amount_eth) / sum(trades.token_trade_amount) as token_price_eth
-    from query_3636570 as trades
-    where trades.t > cast(current_timestamp as timestamp) - interval '1' year
-    group by 1
-),
-
 prices as (
     select
         hours.hr,
-        prices.token_price_eth,
-        prices.token_trade_amount_eth,
-        prices.token_trade_amount
+        prices.token_price_eth
     from hours
     left join
         (select
             hr,
             token_price_eth,
-            token_trade_amount_eth,
-            token_trade_amount,
             lead(hr) over (order by hr) as next_hr
-        from trades) as prices on
+        from query_3661977) as prices on
         hours.hr >= prices.hr
         and hours.hr < prices.next_hr
 )
@@ -66,8 +50,6 @@ select
     avg(prices.token_price_eth)
         over (order by hours.hr rows between 5 preceding and current row)
         as token_price_eth_6hr_ma,
-    prices.token_trade_amount_eth,
-    prices.token_trade_amount,
     peg.token_peg_eth,
     prices.token_price_eth / peg.token_peg_eth as token_price_peg_ratio,
     avg(prices.token_price_eth) over (order by hours.hr rows between 5 preceding and current row)

--- a/lido/wsteth/wsteth_price_peg_ratio.sql
+++ b/lido/wsteth/wsteth_price_peg_ratio.sql
@@ -1,0 +1,80 @@
+/* Dune query number  - 3642007 */
+with hours as (
+    select
+        timestamp as hr,
+        date_trunc('day', timestamp) as d
+    from
+        unnest(
+            sequence(
+                date_trunc('hour', cast(current_timestamp as timestamp) - interval '1' year),
+                cast(current_timestamp as timestamp),
+                interval '60' minute
+            )
+        ) as tbl (timestamp)
+),
+
+peg as (
+    select
+        hours.hr,
+        peg.token_peg_eth
+    from hours
+    left join
+        (select
+            date_trunc('hour', t) as hr,
+            token_peg_eth,
+            lead(date_trunc('hour', t)) over (order by date_trunc('hour', t)) as next_hr
+        from query_3621788) as peg on
+        hours.hr >= peg.hr
+        and hours.hr < peg.next_hr
+),
+
+
+trades as (
+    select
+        date_trunc('hour', trades.t) as hr,
+        sum(trades.token_trade_amount_eth) as token_trade_amount_eth,
+        sum(trades.token_trade_amount) as token_trade_amount,
+        sum(trades.token_trade_amount_eth) / sum(trades.token_trade_amount) as token_price_eth
+    from query_3636570 as trades
+    where trades.t > cast(current_timestamp as timestamp) - interval '1' year
+    group by 1
+),
+
+prices as (
+    select
+        hours.hr,
+        prices.token_price_eth,
+        prices.token_trade_amount_eth,
+        prices.token_trade_amount
+    from hours
+    left join
+        (select
+            hr,
+            token_price_eth,
+            token_trade_amount_eth,
+            token_trade_amount,
+            lead(hr) over (order by hr) as next_hr
+        from trades) as prices on
+        hours.hr >= prices.hr
+        and hours.hr < prices.next_hr
+)
+
+select
+    hours.hr,
+    'wstETH' as token_name,
+    prices.token_price_eth,
+    avg(prices.token_price_eth)
+        over (order by hours.hr rows between 5 preceding and current row)
+        as token_price_eth_6hr_ma,
+    prices.token_trade_amount_eth,
+    prices.token_trade_amount,
+    peg.token_peg_eth,
+    prices.token_price_eth / peg.token_peg_eth as token_price_peg_ratio,
+    avg(prices.token_price_eth) over (order by hours.hr rows between 5 preceding and current row)
+    / peg.token_peg_eth as token_price_peg_ratio_6hr_ma,
+    (prices.token_price_eth / peg.token_peg_eth) - 1 as token_peg_pct_divergence,
+    avg(prices.token_price_eth) over (order by hours.hr rows between 5 preceding and current row) / peg.token_peg_eth
+    - 1 as token_peg_pct_divergence_6hr_ma
+from hours
+left join peg on hours.hr = peg.hr
+left join prices on hours.hr = prices.hr

--- a/lido/wsteth/wsteth_trades.sql
+++ b/lido/wsteth/wsteth_trades.sql
@@ -1,0 +1,44 @@
+/* Dune query number  - 3636570 */
+with
+trades as (
+    select
+        block_time as t,
+        0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0 as token_contract_address,
+        case
+            when token_bought_address = 0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0 then token_bought_amount
+            else token_sold_amount
+        end as token_trade_amount,
+        amount_usd as token_trade_amount_usd
+    from
+        dex.trades
+    where
+        blockchain = 'ethereum'
+        and (
+            token_bought_address = 0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0
+            or token_sold_address = 0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0
+        )
+        and block_time >= cast('2020-10-01' as timestamp)
+        and amount_usd > 10
+)
+
+select
+    trades.t,
+    date_trunc('day', trades.t) as d,
+    trades.token_trade_amount,
+    trades.token_trade_amount_usd,
+    trades.token_trade_amount_usd / cast(prices.price as double) as token_trade_amount_eth,
+    /* Trade size in USD divided by USD/ETH is amount of USD. */
+    'wstETH' as token_name,
+    trades.token_contract_address
+from
+    trades
+inner join
+    prices.usd
+        as prices
+    on prices.minute = date_trunc('minute', trades.t)
+        and prices.symbol = 'WETH'
+        and not trades.token_trade_amount_usd is null /* We need to drop trades if the ETH amount will be unknown. */
+        and not prices.price is null
+        and prices.price > 0
+where
+    prices.blockchain = 'ethereum'

--- a/lido/wsteth/wsteth_trades_peg_ratio.sql
+++ b/lido/wsteth/wsteth_trades_peg_ratio.sql
@@ -1,0 +1,80 @@
+/* Dune query number  - 3642007 */
+with hours as (
+    select
+        timestamp as hr,
+        date_trunc('day', timestamp) as d
+    from
+        unnest(
+            sequence(
+                date_trunc('hour', cast(current_timestamp as timestamp) - interval '1' year),
+                cast(current_timestamp as timestamp),
+                interval '60' minute
+            )
+        ) as tbl (timestamp)
+),
+
+peg as (
+    select
+        hours.hr,
+        peg.token_peg_eth
+    from hours
+    left join
+        (select
+            date_trunc('hour', t) as hr,
+            token_peg_eth,
+            lead(date_trunc('hour', t)) over (order by date_trunc('hour', t)) as next_hr
+        from query_3621788) as peg on
+        hours.hr >= peg.hr
+        and hours.hr < peg.next_hr
+),
+
+
+trades as (
+    select
+        date_trunc('hour', trades.t) as hr,
+        sum(trades.token_trade_amount_eth) as token_trade_amount_eth,
+        sum(trades.token_trade_amount) as token_trade_amount,
+        sum(trades.token_trade_amount_eth) / sum(trades.token_trade_amount) as token_price_eth
+    from query_3636570 as trades
+    where trades.t > cast(current_timestamp as timestamp) - interval '1' year
+    group by 1
+),
+
+prices as (
+    select
+        hours.hr,
+        prices.token_price_eth,
+        prices.token_trade_amount_eth,
+        prices.token_trade_amount
+    from hours
+    left join
+        (select
+            hr,
+            token_price_eth,
+            token_trade_amount_eth,
+            token_trade_amount,
+            lead(hr) over (order by hr) as next_hr
+        from trades) as prices on
+        hours.hr >= prices.hr
+        and hours.hr < prices.next_hr
+)
+
+select
+    hours.hr,
+    'wstETH' as token_name,
+    prices.token_price_eth,
+    avg(prices.token_price_eth)
+        over (order by hours.hr rows between 5 preceding and current row)
+        as token_price_eth_6hr_ma,
+    prices.token_trade_amount_eth,
+    prices.token_trade_amount,
+    peg.token_peg_eth,
+    prices.token_price_eth / peg.token_peg_eth as token_price_peg_ratio,
+    avg(prices.token_price_eth) over (order by hours.hr rows between 5 preceding and current row)
+    / peg.token_peg_eth as token_price_peg_ratio_6hr_ma,
+    (prices.token_price_eth / peg.token_peg_eth) - 1 as token_peg_pct_divergence,
+    avg(prices.token_price_eth) over (order by hours.hr rows between 5 preceding and current row) / peg.token_peg_eth
+    - 1 as token_peg_pct_divergence_6hr_ma
+from hours
+left join peg on hours.hr = peg.hr
+left join prices on hours.hr = prices.hr

--- a/lst/lst_peg.sql
+++ b/lst/lst_peg.sql
@@ -1,0 +1,37 @@
+/* Dune query number  - 3621805 */
+/* rETH */
+select
+    block,
+    t,
+    d,
+    token_peg_eth,
+    token_name,
+    token_contract_address
+from
+    query_3480099
+
+union all
+
+/* stETH */
+select
+    block,
+    t,
+    d,
+    token_peg_eth,
+    token_name,
+    token_contract_address
+from
+    query_3621788
+
+union all
+
+/* cbETH */
+select
+    block,
+    t,
+    d,
+    token_peg_eth,
+    token_name,
+    token_contract_address
+from
+    query_3465256

--- a/lst/lst_price.sql
+++ b/lst/lst_price.sql
@@ -1,0 +1,50 @@
+/* Dune query number  - 3674441 */
+/* wstETH */
+select
+    hr,
+    token_contract_address,
+    token_name,
+    token_price_usd,
+    weth_price_usd,
+    token_price_eth
+from
+    query_3661977
+
+union all
+
+/* stETH */
+select
+    hr,
+    token_contract_address,
+    token_name,
+    token_price_usd,
+    weth_price_usd,
+    token_price_eth
+from
+    query_3664583
+
+union all
+
+/* cbETH */
+select
+    hr,
+    token_contract_address,
+    token_name,
+    token_price_usd,
+    weth_price_usd,
+    token_price_eth
+from
+    query_3661946
+
+union all
+
+/* rETH */
+select
+    hr,
+    token_contract_address,
+    token_name,
+    token_price_usd,
+    weth_price_usd,
+    token_price_eth
+from
+    query_3664567

--- a/lst/lst_price_peg_ratio.sql
+++ b/lst/lst_price_peg_ratio.sql
@@ -43,3 +43,18 @@ select
     token_peg_pct_divergence,
     token_peg_pct_divergence_6hr_ma
 from query_3480205
+union all
+/* wstETH */
+select
+    hr,
+    token_name,
+    token_price_eth,
+    token_price_eth_6hr_ma,
+    token_trade_amount_eth,
+    token_trade_amount,
+    token_peg_eth,
+    token_price_peg_ratio,
+    token_price_peg_ratio_6hr_ma,
+    token_peg_pct_divergence,
+    token_peg_pct_divergence_6hr_ma
+from query_3642007

--- a/lst/lst_trades_peg_ratio.sql
+++ b/lst/lst_trades_peg_ratio.sql
@@ -1,16 +1,18 @@
-/* Dune query number  - 3674480 */
+/* Dune query number  - 3480245 */
 /* rETH */
 select
     hr,
     token_name,
     token_price_eth,
     token_price_eth_6hr_ma,
+    token_trade_amount_eth,
+    token_trade_amount,
     token_peg_eth,
     token_price_peg_ratio,
     token_price_peg_ratio_6hr_ma,
     token_peg_pct_divergence,
     token_peg_pct_divergence_6hr_ma
-from query_3671485
+from query_3480165
 union all
 /* cbETH */
 select
@@ -18,12 +20,14 @@ select
     token_name,
     token_price_eth,
     token_price_eth_6hr_ma,
+    token_trade_amount_eth,
+    token_trade_amount,
     token_peg_eth,
     token_price_peg_ratio,
     token_price_peg_ratio_6hr_ma,
     token_peg_pct_divergence,
     token_peg_pct_divergence_6hr_ma
-from query_3664524
+from query_3465286
 union all
 /* stETH */
 select
@@ -31,12 +35,14 @@ select
     token_name,
     token_price_eth,
     token_price_eth_6hr_ma,
+    token_trade_amount_eth,
+    token_trade_amount,
     token_peg_eth,
     token_price_peg_ratio,
     token_price_peg_ratio_6hr_ma,
     token_peg_pct_divergence,
     token_peg_pct_divergence_6hr_ma
-from query_3668358
+from query_3480205
 union all
 /* wstETH */
 select
@@ -44,9 +50,11 @@ select
     token_name,
     token_price_eth,
     token_price_eth_6hr_ma,
+    token_trade_amount_eth,
+    token_trade_amount,
     token_peg_eth,
     token_price_peg_ratio,
     token_price_peg_ratio_6hr_ma,
     token_peg_pct_divergence,
     token_peg_pct_divergence_6hr_ma
-from query_3656961
+from query_3642007

--- a/rocketpool/reth/reth_price.sql
+++ b/rocketpool/reth/reth_price.sql
@@ -1,0 +1,40 @@
+/* Dune query number  - 3664567 */
+with weth as (
+    select
+        date_trunc('hour', minute) as hr,
+        avg(price) as price
+    from
+        prices.usd
+    where
+        contract_address = 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
+        and minute >= cast(current_timestamp - interval '1' year as timestamp)
+    group by
+        date_trunc('hour', minute)
+)
+,
+token as (
+    select
+        date_trunc('hour', minute) as hr,
+        contract_address,
+        avg(price) as price
+    from
+        prices.usd
+    where
+        contract_address = 0xae78736cd615f374d3085123a210448e74fc6393
+        and minute >= cast(current_timestamp - interval '1' year as timestamp)
+    group by
+        date_trunc('hour', minute),
+        contract_address
+)
+
+select
+    token.hr,
+    token.contract_address as token_contract_address,
+    'rETH' as token_name,
+    token.price as token_price_usd,
+    weth.price as weth_price_usd,
+    token.price / weth.price as token_price_eth
+from
+    token
+inner join weth on
+    token.hr = weth.hr

--- a/rocketpool/reth/reth_trades_peg_ratio.sql
+++ b/rocketpool/reth/reth_trades_peg_ratio.sql
@@ -1,4 +1,4 @@
-/* Dune query number  - 3671485 */
+/* Dune query number  - 3480165 */
 with hours as (
     select
         timestamp as hr,
@@ -28,17 +28,32 @@ peg as (
         and hours.hr < peg.next_hr
 ),
 
+trades as (
+    select
+        date_trunc('hour', trades.t) as hr,
+        sum(trades.token_trade_amount_eth) as token_trade_amount_eth,
+        sum(trades.token_trade_amount) as token_trade_amount,
+        sum(trades.token_trade_amount_eth) / sum(trades.token_trade_amount) as token_price_eth
+    from query_3480086 as trades
+    where trades.t > cast(current_timestamp as timestamp) - interval '1' year
+    group by 1
+),
+
 prices as (
     select
         hours.hr,
-        prices.token_price_eth
+        prices.token_price_eth,
+        prices.token_trade_amount_eth,
+        prices.token_trade_amount
     from hours
     left join
         (select
             hr,
             token_price_eth,
+            token_trade_amount_eth,
+            token_trade_amount,
             lead(hr) over (order by hr) as next_hr
-        from query_3664567) as prices on
+        from trades) as prices on
         hours.hr >= prices.hr
         and hours.hr < prices.next_hr
 )
@@ -50,6 +65,8 @@ select
     avg(prices.token_price_eth)
         over (order by hours.hr rows between 5 preceding and current row)
         as token_price_eth_6hr_ma,
+    prices.token_trade_amount_eth,
+    prices.token_trade_amount,
     peg.token_peg_eth,
     prices.token_price_eth / peg.token_peg_eth as token_price_peg_ratio,
     avg(prices.token_price_eth) over (order by hours.hr rows between 5 preceding and current row)


### PR DESCRIPTION
We have discussed how there is a lot of volatility in the dex trading price that causes our peg divergences to be very choppy with high spikes.

While I still think the trade price is important, I also wanted to compare the peg to quoted price oracles available in Dune.

I created new queries for the quoted price for each LST.

I then created trades_peg_ratio queries which are just the old price_peg_ratio queries comparing dex trades and the peg.

I then flipped the old price_peg_ratio queries to use the quoted price instead of dex trades price.

You can see the result in Price Peg Divergence section here --> https://dune.com/mtitus6/lst-comparison


