### PR TITLE
Add sfrxETH to LST

### DIFF
--- a/frax/sfrxETH/sfrxeth_apy.sql
+++ b/frax/sfrxETH/sfrxeth_apy.sql
@@ -1,0 +1,97 @@
+/* Dune query number  - 3833527 */
+with hours as (
+    select
+        timestamp as hr,
+        date_trunc('day', timestamp) as d
+    from
+        unnest(
+            sequence(
+                date_trunc('hour', cast(current_timestamp as timestamp) - interval '1' year),
+                cast(current_timestamp as timestamp),
+                interval '60' minute
+            )
+        ) as tbl (timestamp)
+)
+,
+
+pre_apy as (
+    select
+        t,
+        date_trunc('hour', t) as hr,
+        d,
+        lag(t) over (order by t) as prev_t,
+        t - lag(t) over (order by t) as t_elapsed,
+        block,
+        lag(block) over (order by block) as prev_block,
+        token_peg_eth,
+        lag(token_peg_eth) over (order by t) as prev_token_peg_eth,
+        100 * (token_peg_eth / lag(token_peg_eth) over (order by t) - 1) as peg_chg,
+        token_contract_address,
+        token_name,
+        lead(date_trunc('hour', t)) over (order by date_trunc('hour', t)) as next_hr
+    from
+        query_3810178
+    where t >= cast(current_timestamp as timestamp) - interval '1' year
+)
+,
+
+apy as (
+    select
+        hours.hr,
+        hours.d,
+        pre_apy.prev_t,
+        pre_apy.block,
+        pre_apy.prev_block,
+        pre_apy.token_peg_eth,
+        pre_apy.prev_token_peg_eth,
+        pre_apy.peg_chg,
+        day(pre_apy.t_elapsed) * 86400 + hour(pre_apy.t_elapsed) * 3600
+        + minute(pre_apy.t_elapsed) * 60 + second(pre_apy.t_elapsed) as t_elapsed,
+        31536000 / nullif(coalesce((
+            day(pre_apy.t_elapsed) * 86400 + hour(pre_apy.t_elapsed) * 3600
+            + minute(pre_apy.t_elapsed) * 60 + second(pre_apy.t_elapsed)
+        ), 0
+        ), 0) * pre_apy.peg_chg as apy,
+        pre_apy.token_contract_address,
+        pre_apy.token_name,
+        case
+            when
+                pre_apy.peg_chg is not null
+                then rank() over (order by case when pre_apy.peg_chg is not null then hours.hr end asc)
+        end as hr_number
+    from hours
+    left join pre_apy on
+        hours.hr >= pre_apy.hr
+        and hours.hr < pre_apy.next_hr
+)
+
+select
+    hr,
+    d,
+    block,
+    token_peg_eth,
+    apy,
+    case when hr_number >= 24 then
+            avg(apy) over (order by hr asc rows between 24 preceding and current row)
+    end as apy_1d,
+    case when hr_number >= 168 then
+            avg(apy) over (order by hr asc rows between 168 preceding and current row)
+    end as apy_7d,
+    case when hr_number >= 720 then
+            avg(apy) over (order by hr asc rows between 720 preceding and current row)
+    end as apy_30d,
+    case when hr_number >= 2160 then
+            avg(apy) over (order by hr asc rows between 2160 preceding and current row)
+    end as apy_90d,
+    case when hr_number >= 2880 then
+            avg(apy) over (order by hr asc rows between 2880 preceding and current row)
+    end as apy_120d,
+    date_trunc('hour', prev_t) as prev_hr,
+    prev_block,
+    prev_token_peg_eth,
+    t_elapsed,
+    peg_chg,
+    token_contract_address,
+    token_name
+from
+    apy

--- a/frax/sfrxETH/sfrxeth_burn.sql
+++ b/frax/sfrxETH/sfrxeth_burn.sql
@@ -1,0 +1,14 @@
+/* Dune query number  - 3810100 */
+select
+    date_trunc('day', evt_block_time) as d,
+    contract_address as token_contract_address,
+    'sfrxETH' as token_name,
+    sum(cast(value as double)) / 1e18 as token_burn_amount
+from
+    erc20_ethereum.evt_transfer
+where
+    contract_address = 0xac3e018457b222d93114458476f3e3416abbe38f
+    and to = 0x0000000000000000000000000000000000000000
+    and evt_block_time >= cast('2022-10-06' as timestamp)
+group by
+    1, 2

--- a/frax/sfrxETH/sfrxeth_mint.sql
+++ b/frax/sfrxETH/sfrxeth_mint.sql
@@ -1,0 +1,14 @@
+/* Dune query number  - 3810083 */
+select
+    date_trunc('day', evt_block_time) as d,
+    contract_address as token_contract_address,
+    'sfrxETH' as token_name,
+    sum(cast(value as double)) / 1e18 as token_mint_amount
+from
+    erc20_ethereum.evt_transfer
+where
+    contract_address = 0xac3e018457b222d93114458476f3e3416abbe38f
+    and "from" = 0x0000000000000000000000000000000000000000
+    and evt_block_time >= cast('2022-10-06' as timestamp)
+group by
+    1, 2

--- a/frax/sfrxETH/sfrxeth_peg.sql
+++ b/frax/sfrxETH/sfrxeth_peg.sql
@@ -1,0 +1,13 @@
+/* Dune query number  - 3810178 */
+select
+    evt_tx_hash,
+    evt_block_time as t,
+    date_trunc('day', evt_block_time) as d,
+    evt_block_number as block,
+    assets / cast(shares as double) as token_peg_eth,
+    0xac3e018457b222d93114458476f3e3416abbe38f as token_contract_address,
+    'sfrxETH' as token_name
+from
+    frax_ethereum.sfrxeth_evt_deposit
+where
+    assets > 100 --filter 3 txs under 100 wei

--- a/frax/sfrxETH/sfrxeth_price.sql
+++ b/frax/sfrxETH/sfrxeth_price.sql
@@ -1,0 +1,40 @@
+/* Dune query number  - 3810147 */
+with weth as (
+    select
+        date_trunc('hour', minute) as hr,
+        avg(price) as price
+    from
+        prices.usd
+    where
+        contract_address = 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
+        and minute >= cast(current_timestamp - interval '1' year as timestamp)
+    group by
+        date_trunc('hour', minute)
+)
+,
+token as (
+    select
+        date_trunc('hour', minute) as hr,
+        contract_address,
+        avg(price) as price
+    from
+        prices.usd
+    where
+        contract_address = 0xac3e018457b222d93114458476f3e3416abbe38f
+        and minute >= cast(current_timestamp - interval '1' year as timestamp)
+    group by
+        date_trunc('hour', minute),
+        contract_address
+)
+
+select
+    token.hr,
+    token.contract_address as token_contract_address,
+    'sfrxETH' as token_name,
+    token.price as token_price_usd,
+    weth.price as weth_price_usd,
+    token.price / weth.price as token_price_eth
+from
+    token
+inner join weth on
+    token.hr = weth.hr

--- a/frax/sfrxETH/sfrxeth_price_peg_ratio.sql
+++ b/frax/sfrxETH/sfrxeth_price_peg_ratio.sql
@@ -1,0 +1,62 @@
+/* Dune query number  - 3833523 */
+with hours as (
+    select
+        timestamp as hr,
+        date_trunc('day', timestamp) as d
+    from
+        unnest(
+            sequence(
+                date_trunc('hour', cast(current_timestamp as timestamp) - interval '1' year),
+                cast(current_timestamp as timestamp),
+                interval '60' minute
+            )
+        ) as tbl (timestamp)
+),
+
+peg as (
+    select
+        hours.hr,
+        peg.token_peg_eth
+    from hours
+    left join
+        (select
+            date_trunc('hour', t) as hr,
+            token_peg_eth,
+            lead(date_trunc('hour', t)) over (order by date_trunc('hour', t)) as next_hr
+        from query_3810178) as peg on
+        hours.hr >= peg.hr
+        and hours.hr < peg.next_hr
+),
+
+prices as (
+    select
+        hours.hr,
+        prices.token_price_eth
+    from hours
+    left join
+        (select
+            hr,
+            token_price_eth,
+            lead(hr) over (order by hr) as next_hr
+        from query_3810147) as prices on
+        hours.hr >= prices.hr
+        and hours.hr < prices.next_hr
+)
+
+select
+    hours.hr,
+    'sfrxETH' as token_name,
+    prices.token_price_eth,
+    avg(prices.token_price_eth)
+        over (order by hours.hr rows between 5 preceding and current row)
+        as token_price_eth_6hr_ma,
+    peg.token_peg_eth,
+    prices.token_price_eth / peg.token_peg_eth as token_price_peg_ratio,
+    avg(prices.token_price_eth) over (order by hours.hr rows between 5 preceding and current row)
+    / peg.token_peg_eth as token_price_peg_ratio_6hr_ma,
+    (prices.token_price_eth / peg.token_peg_eth) - 1 as token_peg_pct_divergence,
+    avg(prices.token_price_eth) over (order by hours.hr rows between 5 preceding and current row) / peg.token_peg_eth
+    - 1 as token_peg_pct_divergence_6hr_ma
+from hours
+left join peg on hours.hr = peg.hr
+left join prices on hours.hr = prices.hr

--- a/frax/sfrxETH/sfrxeth_supply.sql
+++ b/frax/sfrxETH/sfrxeth_supply.sql
@@ -1,0 +1,32 @@
+/* Dune query number  - 3810114 */
+with days as (select tbl.d from unnest(sequence(date('2022-10-06'), current_date, interval '1' day)) as tbl (d)
+),
+
+totals as (
+    select
+        days.d,
+        cast(coalesce(sum(mint.token_mint_amount), 0) as double) as token_mint_amount,
+        cast(coalesce(sum(burn.token_burn_amount), 0) as double) as token_burn_amount,
+        cast(coalesce(sum(mint.token_mint_amount), 0) as double)
+        - cast(coalesce(sum(burn.token_burn_amount), 0) as double) as token_supply_change_amount
+    from days
+    left join
+        query_3810083 as mint
+        on days.d = mint.d
+    left join
+        query_3810100 as burn
+        on days.d = burn.d
+    group by 1
+)
+
+select
+    d,
+    token_mint_amount,
+    token_burn_amount,
+    token_supply_change_amount,
+    sum(token_mint_amount) over (order by d asc) as token_total_mint,
+    sum(token_burn_amount) over (order by d asc) as token_total_burn,
+    sum(token_supply_change_amount) over (order by d asc) as token_total_supply,
+    'sfrxETH' as token_name
+from totals
+order by 1 desc

--- a/frax/sfrxETH/sfrxeth_trades.sql
+++ b/frax/sfrxETH/sfrxeth_trades.sql
@@ -1,0 +1,44 @@
+/* Dune query number  - 3810156 */
+with
+trades as (
+    select
+        block_time as t,
+        0xac3e018457b222d93114458476f3e3416abbe38f as token_contract_address,
+        case
+            when token_bought_address = 0xac3e018457b222d93114458476f3e3416abbe38f then token_bought_amount
+            else token_sold_amount
+        end as token_trade_amount,
+        amount_usd as token_trade_amount_usd
+    from
+        dex.trades
+    where
+        blockchain = 'ethereum'
+        and (
+            token_bought_address = 0xac3e018457b222d93114458476f3e3416abbe38f
+            or token_sold_address = 0xac3e018457b222d93114458476f3e3416abbe38f
+        )
+        and block_time >= cast('2022-10-06' as timestamp)
+        and amount_usd > 10
+)
+
+select
+    trades.t,
+    date_trunc('day', trades.t) as d,
+    trades.token_trade_amount,
+    trades.token_trade_amount_usd,
+    trades.token_trade_amount_usd / cast(prices.price as double) as token_trade_amount_eth,
+    /* Trade size in USD divided by USD/ETH is amount of USD. */
+    'sfrxETH' as token_name,
+    trades.token_contract_address
+from
+    trades
+inner join
+    prices.usd
+        as prices
+    on prices.minute = date_trunc('minute', trades.t)
+        and prices.symbol = 'WETH'
+        and not trades.token_trade_amount_usd is null /* We need to drop trades if the ETH amount will be unknown. */
+        and not prices.price is null
+        and prices.price > 0
+where
+    prices.blockchain = 'ethereum'

--- a/frax/sfrxETH/sfrxeth_trades_peg_ratio.sql
+++ b/frax/sfrxETH/sfrxeth_trades_peg_ratio.sql
@@ -1,0 +1,79 @@
+/* Dune query number  - 3833519 */
+with hours as (
+    select
+        timestamp as hr,
+        date_trunc('day', timestamp) as d
+    from
+        unnest(
+            sequence(
+                date_trunc('hour', cast(current_timestamp as timestamp) - interval '1' year),
+                cast(current_timestamp as timestamp),
+                interval '60' minute
+            )
+        ) as tbl (timestamp)
+),
+
+peg as (
+    select
+        hours.hr,
+        peg.token_peg_eth
+    from hours
+    left join
+        (select
+            date_trunc('hour', t) as hr,
+            token_peg_eth,
+            lead(date_trunc('hour', t)) over (order by date_trunc('hour', t)) as next_hr
+        from query_3810178) as peg on
+        hours.hr >= peg.hr
+        and hours.hr < peg.next_hr
+),
+
+trades as (
+    select
+        date_trunc('hour', trades.t) as hr,
+        sum(trades.token_trade_amount_eth) as token_trade_amount_eth,
+        sum(trades.token_trade_amount) as token_trade_amount,
+        sum(trades.token_trade_amount_eth) / sum(trades.token_trade_amount) as token_price_eth
+    from query_3810156 as trades
+    where trades.t > cast(current_timestamp as timestamp) - interval '1' year
+    group by 1
+),
+
+prices as (
+    select
+        hours.hr,
+        prices.token_price_eth,
+        prices.token_trade_amount_eth,
+        prices.token_trade_amount
+    from hours
+    left join
+        (select
+            hr,
+            token_price_eth,
+            token_trade_amount_eth,
+            token_trade_amount,
+            lead(hr) over (order by hr) as next_hr
+        from trades) as prices on
+        hours.hr >= prices.hr
+        and hours.hr < prices.next_hr
+)
+
+select
+    hours.hr,
+    'sfrxETH' as token_name,
+    prices.token_price_eth,
+    avg(prices.token_price_eth)
+        over (order by hours.hr rows between 5 preceding and current row)
+        as token_price_eth_6hr_ma,
+    prices.token_trade_amount_eth,
+    prices.token_trade_amount,
+    peg.token_peg_eth,
+    prices.token_price_eth / peg.token_peg_eth as token_price_peg_ratio,
+    avg(prices.token_price_eth) over (order by hours.hr rows between 5 preceding and current row)
+    / peg.token_peg_eth as token_price_peg_ratio_6hr_ma,
+    (prices.token_price_eth / peg.token_peg_eth) - 1 as token_peg_pct_divergence,
+    avg(prices.token_price_eth) over (order by hours.hr rows between 5 preceding and current row) / peg.token_peg_eth
+    - 1 as token_peg_pct_divergence_6hr_ma
+from hours
+left join peg on hours.hr = peg.hr
+left join prices on hours.hr = prices.hr

--- a/lst/lst_apy.sql
+++ b/lst/lst_apy.sql
@@ -92,3 +92,27 @@ select
     token_name
 from
     query_3784128
+
+union
+
+/* sfrxETH */
+select
+    hr,
+    d,
+    block,
+    token_peg_eth,
+    apy,
+    apy_1d,
+    apy_7d,
+    apy_30d,
+    apy_90d,
+    apy_120d,
+    prev_hr,
+    prev_block,
+    prev_token_peg_eth,
+    t_elapsed,
+    peg_chg,
+    token_contract_address,
+    token_name
+from
+    query_3833527

--- a/lst/lst_peg.sql
+++ b/lst/lst_peg.sql
@@ -49,6 +49,20 @@ with peg as (
         token_contract_address
     from
         query_3766963
+
+    union all
+
+    /* sfrxETH */
+    select
+        block,
+        t,
+        d,
+        token_peg_eth,
+        token_name,
+        token_contract_address
+    from
+        query_3810178
+
 )
 ,
 times as (

--- a/lst/lst_price.sql
+++ b/lst/lst_price.sql
@@ -74,3 +74,16 @@ select
     token_price_eth
 from
     query_3763815
+
+union all
+
+/* sfrxETH */
+select
+    hr,
+    token_contract_address,
+    token_name,
+    token_price_usd,
+    weth_price_usd,
+    token_price_eth
+from
+    query_3810147

--- a/lst/lst_price_peg_ratio.sql
+++ b/lst/lst_price_peg_ratio.sql
@@ -71,3 +71,18 @@ select
     token_peg_pct_divergence,
     token_peg_pct_divergence_6hr_ma
 from query_3784108
+
+union all
+
+/* sfrxETH */
+select
+    hr,
+    token_name,
+    token_price_eth,
+    token_price_eth_6hr_ma,
+    token_peg_eth,
+    token_price_peg_ratio,
+    token_price_peg_ratio_6hr_ma,
+    token_peg_pct_divergence,
+    token_peg_pct_divergence_6hr_ma
+from query_3833523

--- a/lst/lst_supply.sql
+++ b/lst/lst_supply.sql
@@ -66,3 +66,17 @@ select
     token_total_supply,
     token_name
 from query_3763838
+
+union all
+
+/* sfrxETH */
+select
+    d,
+    token_mint_amount,
+    token_burn_amount,
+    token_supply_change_amount,
+    token_total_mint,
+    token_total_burn,
+    token_total_supply,
+    token_name
+from query_3810114

--- a/lst/lst_trades_peg_ratio.sql
+++ b/lst/lst_trades_peg_ratio.sql
@@ -81,3 +81,20 @@ select
     token_peg_pct_divergence,
     token_peg_pct_divergence_6hr_ma
 from query_3784121
+
+union all
+
+/* sfrxETH */
+select
+    hr,
+    token_name,
+    token_price_eth,
+    token_price_eth_6hr_ma,
+    token_trade_amount_eth,
+    token_trade_amount,
+    token_peg_eth,
+    token_price_peg_ratio,
+    token_price_peg_ratio_6hr_ma,
+    token_peg_pct_divergence,
+    token_peg_pct_divergence_6hr_ma
+from query_3833519


### PR DESCRIPTION
Added sfrxETH to LST.

Result is here --> [LST Comparison (rebuild)](https://dune.com/mtitus6/lst-comparison)

sfrxETH does not have a price on coinpaprika so Price/Peg section will be missing until it is added.  frxETH (pegged to ETH) is there but not the staked variety.

Will merge in a week, so you have time to review.