### PR TITLE
Add rETH pools and liquidity

### DIFF
--- a/rocketpool/reth/reth_liquidity.sql
+++ b/rocketpool/reth/reth_liquidity.sql
@@ -1,0 +1,67 @@
+/* Dune query number  - 4090664 */
+with
+pools as (
+    select
+        project,
+        blockchain,
+        pool
+    from query_4098252
+)
+,
+erc20_in as (
+    select
+        transfers.blockchain,
+        pool.pool,
+        transfers.d,
+        sum(transfers.value) as amount_in
+    from pools as pool
+    inner join query_4098262 as transfers
+        on pool.pool = transfers.to and pool.blockchain = transfers.blockchain
+    group by 1, 2, 3
+)
+,
+erc20_out as (
+    select
+        transfers.blockchain,
+        pool.pool,
+        transfers.d,
+        sum(transfers.value) as amount_out
+    from pools as pool
+    inner join query_4098262 as transfers
+        on pool.pool = transfers."from" and pool.blockchain = transfers.blockchain
+    group by 1, 2, 3
+)
+,
+days as (
+    select distinct
+        tbl.d,
+        pools.pool,
+        pools.blockchain
+    from unnest(sequence(date('2021-10-02'), current_date, interval '1' day)) as tbl (d)
+    cross join pools
+)
+,
+erc20_agg as (
+    select
+        days.pool,
+        days.blockchain,
+        days.d,
+        (cast(amount_in as double) - coalesce(cast(amount_out as double), 0))
+        / pow(10, 18) as balance
+    from days
+    left join erc20_in on days.d = erc20_in.d and days.pool = erc20_in.pool and days.blockchain = erc20_in.blockchain
+    left join
+        erc20_out
+        on days.d = erc20_out.d and days.pool = erc20_out.pool and days.blockchain = erc20_out.blockchain
+)
+
+select
+    pools.project,
+    pools.blockchain,
+    erc20_agg.d,
+    erc20_agg.pool,
+    'rETH' as token_name,
+    sum(erc20_agg.balance) as net_flow
+from erc20_agg
+left join pools on erc20_agg.pool = pools.pool and erc20_agg.blockchain = pools.blockchain
+group by 1, 2, 3, 4

--- a/rocketpool/reth/reth_pools.sql
+++ b/rocketpool/reth/reth_pools.sql
@@ -1,0 +1,45 @@
+/* Dune query number  - 4098252 */
+select distinct
+    project,
+    blockchain,
+    --same vault on all chains, holds tokens for all pools.
+    case
+        when project = 'balancer'
+            and version = '2' then 0xba12222222228d8ba445958a75a0704d566bf2c8
+        else project_contract_address
+    end as pool,
+    'rETH' as token_name
+from
+    dex.trades
+where
+    (
+        (
+            blockchain = 'ethereum'
+            and (
+                token_sold_address = 0xae78736cd615f374d3085123a210448e74fc6393
+                or token_bought_address = 0xae78736cd615f374d3085123a210448e74fc6393
+            )
+        )
+        or (
+            blockchain = 'arbitrum'
+            and (
+                token_sold_address = 0xec70dcb4a1efa46b8f2d97c310c9c4790ba5ffa8
+                or token_bought_address = 0xec70dcb4a1efa46b8f2d97c310c9c4790ba5ffa8
+            )
+        )
+        or (
+            blockchain = 'optimism'
+            and (
+                token_sold_address = 0x9bcef72be871e61ed4fbbc7630889bee758eb81d
+                or token_bought_address = 0x9bcef72be871e61ed4fbbc7630889bee758eb81d
+            )
+        )
+        or (
+            blockchain = 'base'
+            and (
+                token_sold_address = 0xb6fe221fe9eef5aba221c348ba20a1bf5e73624c
+                or token_bought_address = 0xb6fe221fe9eef5aba221c348ba20a1bf5e73624c
+            )
+        )
+    )
+    and block_time >= cast('2021-10-02' as timestamp)

--- a/rocketpool/reth/reth_transfers.sql
+++ b/rocketpool/reth/reth_transfers.sql
@@ -1,0 +1,34 @@
+/* Dune query number  - 4098262 */
+select
+    transfers.blockchain,
+    'rETH' as token_name,
+    transfers.to,
+    transfers."from",
+    transfers.evt_block_time,
+    date_trunc('day', transfers.evt_block_time) as d,
+    transfers.value
+from
+    evms.erc20_transfers as transfers
+where
+/*rETH address */
+    ((
+        transfers.blockchain = 'ethereum'
+        and transfers.contract_address = transfers.0xae78736cd615f374d3085123a210448e74fc6393
+    )
+    or
+    (
+        transfers.blockchain = 'arbitrum'
+        and transfers.contract_address = transfers.0xec70dcb4a1efa46b8f2d97c310c9c4790ba5ffa8
+    )
+    or
+    (
+        transfers.blockchain = 'optimism'
+        and transfers.contract_address = transfers.0x9bcef72be871e61ed4fbbc7630889bee758eb81d
+    )
+    or
+    (
+        transfers.blockchain = 'base'
+        and transfers.contract_address = transfers.0xb6fe221fe9eef5aba221c348ba20a1bf5e73624c
+    ))
+    and transfers.evt_block_time >= cast('2021-10-02' as timestamp)
+    and transfers.value > 0

--- a/rocketpool/reth/reth_transfers.sql
+++ b/rocketpool/reth/reth_transfers.sql
@@ -1,34 +1,34 @@
 /* Dune query number  - 4098262 */
 select
-    transfers.blockchain,
+    blockchain,
     'rETH' as token_name,
-    transfers.to,
-    transfers."from",
-    transfers.evt_block_time,
-    date_trunc('day', transfers.evt_block_time) as d,
-    transfers.value
+    to,
+    "from",
+    evt_block_time,
+    date_trunc('day', evt_block_time) as d,
+    value
 from
-    evms.erc20_transfers as transfers
+    evms.erc20_transfers
 where
 /*rETH address */
     ((
-        transfers.blockchain = 'ethereum'
-        and transfers.contract_address = transfers.0xae78736cd615f374d3085123a210448e74fc6393
+        blockchain = 'ethereum'
+        and contract_address = 0xae78736cd615f374d3085123a210448e74fc6393
     )
     or
     (
-        transfers.blockchain = 'arbitrum'
-        and transfers.contract_address = transfers.0xec70dcb4a1efa46b8f2d97c310c9c4790ba5ffa8
+        blockchain = 'arbitrum'
+        and contract_address = 0xec70dcb4a1efa46b8f2d97c310c9c4790ba5ffa8
     )
     or
     (
-        transfers.blockchain = 'optimism'
-        and transfers.contract_address = transfers.0x9bcef72be871e61ed4fbbc7630889bee758eb81d
+        blockchain = 'optimism'
+        and contract_address = 0x9bcef72be871e61ed4fbbc7630889bee758eb81d
     )
     or
     (
-        transfers.blockchain = 'base'
-        and transfers.contract_address = transfers.0xb6fe221fe9eef5aba221c348ba20a1bf5e73624c
+        blockchain = 'base'
+        and contract_address = 0xb6fe221fe9eef5aba221c348ba20a1bf5e73624c
     ))
-    and transfers.evt_block_time >= cast('2021-10-02' as timestamp)
-    and transfers.value > 0
+    and evt_block_time >= cast('2021-10-02' as timestamp)
+    and value > 0


### PR DESCRIPTION
Added three base primitives that combined can be used to construct liquidity queries for rETH

Transfers - https://dune.com/queries/4098262
Pools - https://dune.com/queries/4098252
Liquidity - https://dune.com/queries/4090664

Example usage can be liquidity by chain or liquidity by DEX
By DEX - https://dune.com/queries/4098434/6901784
By Chain - https://dune.com/queries/4101274