### PR TITLE
Add minipool and node queries

### DIFF
--- a/.sqlfluff
+++ b/.sqlfluff
@@ -11,7 +11,7 @@ templater = jinja
 # See https://docs.sqlfluff.com/en/stable/configuration.html#enabling-and-disabling-rules
 # AM04 (ambiguous.column_count) and ST06 (structure.column_order) are
 # two of the more controversial rules included to illustrate usage.
-exclude_rules = ambiguous.column_count, structure.column_order, structure.subquery, aliasing.unused, references.qualification
+exclude_rules = ambiguous.column_count, structure.column_order, structure.subquery, aliasing.unused, references.qualification, capitalisation.identifiers
 
 # The standard max_line_length is 80 in line with the convention of
 # other tools and several style guides. Many projects however prefer

--- a/node_operator/node_master.sql
+++ b/node_operator/node_master.sql
@@ -1,4 +1,4 @@
-/* Dune query number  - 4125671 */
+/* Dune query number  - 4351977 */
 with minipools as (
     select
         node_address,

--- a/node_operator/node_master.sql
+++ b/node_operator/node_master.sql
@@ -36,15 +36,13 @@ select
     nodes.node_address,
     nodes.node_ens,
     nodes.t as node_registered_t,
-    minipools.total_minipools,
-    minipools.active_minipools,
-    minipools.exited_minipools,
-    minipools.active_effective_stake,
-    minipools.active_bond_amount,
-    minipools.active_effective_stake - minipools.active_bond_amount as active_borrowed_amount,
-    rpl_stake.rpl_staked_amount,
-    (select rpl_price_usd from rpl_price)
-    / (select weth_price_usd from weth_price) as rpl_weth_price_ratio,
+    coalesce(minipools.total_minipools, 0) as total_minipools,
+    coalesce(minipools.active_minipools, 0) as active_minipools,
+    coalesce(minipools.exited_minipools, 0) as exited_minipools,
+    coalesce(minipools.active_effective_stake, 0) as active_effective_stake,
+    coalesce(minipools.active_bond_amount, 0) as active_bond_amount,
+    coalesce(minipools.active_effective_stake - minipools.active_bond_amount, 0) as active_borrowed_amount,
+    coalesce(rpl_stake.rpl_staked_amount, 0) as rpl_staked_amount,
     (select rpl_price_usd from rpl_price)
     / (select weth_price_usd from weth_price) * rpl_stake.rpl_staked_amount as rpl_staked_amount_weth,
     case when minipools.active_effective_stake > 0
@@ -56,9 +54,9 @@ select
                 )
                 / (minipools.active_effective_stake - minipools.active_bond_amount)
         else 0
-    end as rpl_collateral_ratio,
-    smooth.in_smoothing_pool,
-    smooth.t as in_smoothing_pool_t
+    end as rpl_vs_borrowed_ratio,
+    coalesce(smooth.in_smoothing_pool, false) as in_smoothing_pool,
+    coalesce(smooth.t, nodes.t) as in_smoothing_pool_t
 from query_4108312 as nodes /* node_operators */
 left join minipools on nodes.node_address = minipools.node_address
 left join rpl_stake on nodes.node_address = rpl_stake.node_address

--- a/node_operator/node_master.sql
+++ b/node_operator/node_master.sql
@@ -1,0 +1,65 @@
+/* Dune query number  - 4125671 */
+with minipools as (
+    select
+        node_address,
+        sum(case when beacon_amount_deposited > 0 then 1 else 0 end) as total_minipools,
+        sum(case when beacon_amount_deposited > 1 and exited = false then 1 else 0 end) as active_minipools,
+        sum(case when beacon_amount_deposited > 1 and exited = true then 1 else 0 end) as exited_minipools,
+        sum(case when exited = false and beacon_amount_deposited > 1 then beacon_amount_deposited else 0 end)
+            as active_effective_stake,
+        sum(case when exited = false and beacon_amount_deposited > 1 then bond_amount else 0 end) as active_bond_amount
+    from query_4125671 /*minipool_master*/
+    group by 1
+)
+,
+rpl_stake as (
+    select
+        node_address,
+        round(sum(amount), 8) as rpl_staked_amount
+    from query_4108361 /*node_rpl_staking*/
+    group by 1
+)
+,
+rpl_price as (
+    select price as rpl_price_usd
+    from prices.usd_latest
+    where contract_address = 0xD33526068D116cE69F19A9ee46F0bd304F21A51f
+)
+,
+weth_price as (
+    select price as weth_price_usd
+    from prices.usd_latest
+    where contract_address = 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
+)
+
+select
+    nodes.node_address,
+    nodes.node_ens,
+    nodes.t as node_registered_t,
+    minipools.total_minipools,
+    minipools.active_minipools,
+    minipools.exited_minipools,
+    minipools.active_effective_stake,
+    minipools.active_bond_amount,
+    minipools.active_effective_stake - minipools.active_bond_amount as active_borrowed_amount,
+    rpl_stake.rpl_staked_amount,
+    (select rpl_price_usd from rpl_price)
+    / (select weth_price_usd from weth_price) as rpl_weth_price_ratio,
+    (select rpl_price_usd from rpl_price)
+    / (select weth_price_usd from weth_price) * rpl_stake.rpl_staked_amount as rpl_staked_amount_weth,
+    case when minipools.active_effective_stake > 0
+            then
+                (
+                    (select rpl_price_usd from rpl_price
+                    ) / (select weth_price_usd from weth_price
+                    ) * rpl_stake.rpl_staked_amount
+                )
+                / (minipools.active_effective_stake - minipools.active_bond_amount)
+        else 0
+    end as rpl_collateral_ratio,
+    smooth.in_smoothing_pool,
+    smooth.t as in_smoothing_pool_t
+from query_4108312 as nodes /* node_operators */
+left join minipools on nodes.node_address = minipools.node_address
+left join rpl_stake on nodes.node_address = rpl_stake.node_address
+left join query_4118898 as smooth on nodes.node_address = smooth.node_address

--- a/node_operator/node_operators.sql
+++ b/node_operator/node_operators.sql
@@ -1,0 +1,23 @@
+/* Dune query number  - 4108312 */
+with registered as (
+    select
+        node as node_address,
+        evt_block_time as t
+    from
+        rocketpool_ethereum.rocketnodemanager_evt_noderegistered
+)
+,
+ens as (
+    select
+        address,
+        name
+    from
+        ens.reverse_latest
+)
+
+select
+    reg.node_address,
+    ens.name as node_ens,
+    reg.t
+from registered as reg
+left join ens on reg.node_address = ens.address

--- a/node_operator/node_rpl_staking.sql
+++ b/node_operator/node_rpl_staking.sql
@@ -1,0 +1,46 @@
+/* Dune query number  - 4108361 */
+with
+rpl_staked as (
+    select
+        "from" as node_address,
+        cast(amount / 1e18 as double) as amount,
+        evt_block_time as t
+    from
+        rocketpool_ethereum.RocketNodeStaking_evt_RPLStaked
+)
+,
+rpl_withdrawn as (
+    select
+        to as node_address,
+        -1 * cast(amount / 1e18 as double) as amount,
+        evt_block_time as t
+    from
+        rocketpool_ethereum.RocketNodeStaking_evt_RPLWithdrawn
+)
+,
+rpl_slashed as (
+    select
+        node as node_address,
+        evt_block_time as t,
+        -1 * cast(amount / 1e18 as double) as amount
+    from
+        rocketpool_ethereum.RocketNodeStaking_evt_RPLSlashed
+)
+
+select
+    node_address,
+    t,
+    amount
+from rpl_staked
+union all
+select
+    node_address,
+    t,
+    amount
+from rpl_withdrawn
+union all
+select
+    node_address,
+    t,
+    amount
+from rpl_slashed

--- a/node_operator/node_rpl_staking.sql
+++ b/node_operator/node_rpl_staking.sql
@@ -30,17 +30,20 @@ rpl_slashed as (
 select
     node_address,
     t,
-    amount
+    amount,
+    'staked' as cat
 from rpl_staked
 union all
 select
     node_address,
     t,
-    amount
+    amount,
+    'withdrawn' as cat
 from rpl_withdrawn
 union all
 select
     node_address,
     t,
-    amount
+    amount,
+    'slashed' as cat
 from rpl_slashed

--- a/node_operator/node_smoothing_pool.sql
+++ b/node_operator/node_smoothing_pool.sql
@@ -1,0 +1,9 @@
+/* Dune query number  - 4118898 */
+select
+    node as node_address,
+    max(evt_block_time) as t,
+    max_by(state, evt_block_time) as in_smoothing_pool
+from
+    rocketpool_ethereum.rocketnodemanager_evt_nodesmoothingpoolstatechanged
+group by
+    node

--- a/rocketpool/rpl/rpl_staked.sql
+++ b/rocketpool/rpl/rpl_staked.sql
@@ -1,0 +1,42 @@
+with
+nodes as (
+    select node_address
+    from
+        query_4108312
+)
+,
+rpl_staked as (
+    select
+        "from" as node_address,
+        cast(amount / 1e18 as double) as amount,
+        evt_block_time as t
+    from
+        rocketpool_ethereum.RocketNodeStaking_evt_RPLStaked
+)
+,
+rpl_withdrawn as (
+    select
+        to as node_address,
+        -1 * cast(amount / 1e18 as double) as amount,
+        evt_block_time as t
+    from
+        rocketpool_ethereum.RocketNodeStaking_evt_RPLWithdrawn
+)
+,
+rpl_slashed as (
+    select
+        node as node_address,
+        -1 * cast(amount / 1e18 as double) as amount,
+        evt_block_time as t
+    from
+        rocketpool_ethereum.RocketNodeStaking_evt_RPLSlashed
+)
+
+select
+    nodes.node_address,
+    coalesce(rpl_staked.t, rpl_withdrawn.t, rpl_slashed.t) as t,
+    coalesce(rpl_staked.amount, rpl_withdrawn.amount, rpl_slashed.amount) as amount
+from nodes
+left join rpl_staked on nodes.node_address = rpl_staked.node_address
+left join rpl_withdrawn on nodes.node_address = rpl_withdrawn.node_address
+left join rpl_slashed on nodes.node_address = rpl_slashed.node_address

--- a/rocketpool/rpl/rpl_staked.sql
+++ b/rocketpool/rpl/rpl_staked.sql
@@ -7,8 +7,8 @@ staked as (
         date_trunc('day', t) as d,
         sum(amount) as amount
     from query_4108361 group by 1
-),
-
+)
+,
 totals as (
     select
         days.d,

--- a/rocketpool/validator/minipool_balance_distributed.sql
+++ b/rocketpool/validator/minipool_balance_distributed.sql
@@ -1,0 +1,12 @@
+/* Dune query number  - 4125568 */
+select
+    trans.to as minipool,
+    true as is_distributed
+from
+    rocketpool_ethereum.RocketMinipoolDelegate_call_distributeBalance as dist
+inner join ethereum.transactions as trans on dist.call_tx_hash = trans.hash
+where
+    dist.call_block_time > timestamp '2023-04-01'
+    and trans.block_time > timestamp '2023-04-01'
+    and dist._rewardsOnly = false -- Only full minipool distributions
+    and dist.call_success = true

--- a/rocketpool/validator/minipool_beacon_deposit.sql
+++ b/rocketpool/validator/minipool_beacon_deposit.sql
@@ -1,0 +1,23 @@
+/* Dune query number  - 4119023 */
+with
+pub_key as (
+    select
+        minipool,
+        pubkey
+    from
+        query_4250058 --minipool_deposit
+)
+
+select
+    pub_key.minipool,
+    pub_key.pubkey,
+    sum(
+        bytearray_to_uint256(bytearray_reverse(dep.amount)) / 1e9
+    ) as beacon_amount_deposited
+from
+    pub_key
+inner join eth2_ethereum.DepositContract_evt_DepositEvent as dep
+    on pub_key.pubkey = dep.pubkey
+group by
+    1,
+    2

--- a/rocketpool/validator/minipool_beacon_withdrawal.sql
+++ b/rocketpool/validator/minipool_beacon_withdrawal.sql
@@ -6,7 +6,7 @@ pub_key as (
         pubkey,
         validator_index
     from
-        query_4250134 --validator_pubkey_index
+        query_4250134 --minipool_pubkey_index
 ),
 
 withdrawals as (

--- a/rocketpool/validator/minipool_beacon_withdrawal.sql
+++ b/rocketpool/validator/minipool_beacon_withdrawal.sql
@@ -1,0 +1,37 @@
+/* Dune query number  - 4125574 */
+with
+pub_key as (
+    select
+        minipool,
+        pubkey,
+        validator_index
+    from
+        query_4250134 --validator_pubkey_index
+),
+
+withdrawals as (
+    select
+        wth.block_time as t,
+        pky.validator_index,
+        wth.amount / 1e9 as amount,
+        pky.minipool,
+        pky.pubkey
+    from
+        pub_key as pky
+    inner join ethereum.withdrawals as wth
+        on pky.validator_index = wth.validator_index
+)
+
+select
+    minipool,
+    validator_index,
+    pubkey,
+    sum(amount) as beacon_amount_withdrawn,
+    sum(if(amount < 8, amount, 0)) as beacon_amount_skim_withdrawn,
+    bool_or(amount > 8) as exited
+from
+    withdrawals
+group by
+    1,
+    2,
+    3

--- a/rocketpool/validator/minipool_beacon_withdrawal.sql
+++ b/rocketpool/validator/minipool_beacon_withdrawal.sql
@@ -26,6 +26,7 @@ select
     minipool,
     validator_index,
     pubkey,
+    max(t) as last_withdrawal_t,
     sum(amount) as beacon_amount_withdrawn,
     sum(if(amount < 8, amount, 0)) as beacon_amount_skim_withdrawn,
     bool_or(amount > 8) as exited

--- a/rocketpool/validator/minipool_bond_reduction.sql
+++ b/rocketpool/validator/minipool_bond_reduction.sql
@@ -1,0 +1,7 @@
+/* Dune query number  - 4118925 */
+select
+    minipool,
+    evt_block_time as t,
+    newBondAmount / 1e18 as new_bond_amount,
+    0.14 as new_node_fee
+from rocketpool_ethereum.RocketMinipoolBondReducer_evt_BeginBondReduction

--- a/rocketpool/validator/minipool_created_destroyed.sql
+++ b/rocketpool/validator/minipool_created_destroyed.sql
@@ -1,0 +1,29 @@
+/* Dune query number  - 4108319 */
+with created as (
+    select
+        minipool,
+        node as node_address,
+        contract_address,
+        evt_block_time as created_t
+    from
+        rocketpool_ethereum.rocketminipoolmanager_evt_minipoolcreated
+)
+,
+destroyed as (
+    select
+        minipool,
+        node as node_address,
+        contract_address,
+        evt_block_time as destroyed_t
+    from
+        rocketpool_ethereum.rocketminipoolmanager_evt_minipooldestroyed
+)
+
+select
+    created.minipool,
+    created.node_address,
+    created.contract_address,
+    created.created_t,
+    destroyed.destroyed_t
+from created
+left join destroyed on created.minipool = destroyed.minipool

--- a/rocketpool/validator/minipool_deposit.sql
+++ b/rocketpool/validator/minipool_deposit.sql
@@ -1,0 +1,35 @@
+/* Dune query number  - 4250058 */
+
+/* minipool_deposit_standard */
+select
+    minipool,
+    t,
+    bond_amount,
+    pubkey,
+    node_fee,
+    'standard' as deposit_type
+from query_4118904
+
+union all
+
+/* minipool_deposit_credit */
+select
+    minipool,
+    t,
+    bond_amount,
+    pubkey,
+    node_fee,
+    'credit' as deposit_type
+from query_4118914
+
+union all
+
+/* minipool_deposit_vacant */
+select
+    minipool,
+    t,
+    bond_amount,
+    pubkey,
+    node_fee,
+    'vacant' as deposit_type
+from query_4129671

--- a/rocketpool/validator/minipool_deposit_credit.sql
+++ b/rocketpool/validator/minipool_deposit_credit.sql
@@ -1,0 +1,36 @@
+/* Dune query number  - 4118914 */
+with
+deposit_with_credit_calls as (
+    select
+        _expectedMinipoolAddress as minipool,
+        call_block_time as t,
+        call_tx_hash as tx_hash,
+        coalesce(_bondAmount, cast('16000000000000000000' as uint256)) as bond_amount, -- noqa
+        _validatorPubkey as pubkey,
+        _minimumNodeFee / 1e18 as node_fee
+    from
+        rocketpool_ethereum.RocketNodeDeposit_call_depositWithCredit
+    where
+        call_success = true
+),
+
+transaction_values as (
+    select
+        hash,
+        value
+    from
+        ethereum.transactions
+    where
+        block_time > cast('2023-04-16' as timestamp)
+)
+
+select
+    dep.minipool,
+    dep.t,
+    dep.bond_amount / 1e18 as bond_amount,
+    dep.pubkey,
+    dep.node_fee
+from
+    deposit_with_credit_calls as dep
+inner join transaction_values as trans on dep.tx_hash = trans.hash
+where trans.value <= dep.bond_amount

--- a/rocketpool/validator/minipool_deposit_standard.sql
+++ b/rocketpool/validator/minipool_deposit_standard.sql
@@ -1,0 +1,12 @@
+/* Dune query number  - 4118904 */
+select
+    _expectedMinipoolAddress as minipool,
+    call_block_time as t,
+    coalesce(_bondAmount / 1e18, 16) as bond_amount,
+    _validatorPubkey as pubkey,
+    _minimumNodeFee / 1e18 as node_fee
+from
+    rocketpool_ethereum.RocketNodeDeposit_call_deposit
+where
+    call_success = true
+    and _expectedMinipoolAddress is not null

--- a/rocketpool/validator/minipool_deposit_vacant.sql
+++ b/rocketpool/validator/minipool_deposit_vacant.sql
@@ -1,0 +1,38 @@
+/* Dune query number  - 4129671 */
+with deposits as (
+    select
+        _expectedminipooladdress as minipool,
+        call_block_time as t,
+        _bondamount / 1e18 as bond_amount,
+        _validatorpubkey as pubkey,
+        _minimumnodefee as node_fee
+    from
+        rocketpool_ethereum.rocketnodedeposit_call_createvacantminipool
+    where call_success = true
+)
+,
+/* there were duplicate public keys used on 5 vacant minipools.  this will ensure minipool is valid */
+promoted as (
+    select to as minipool
+    from
+        ethereum.transactions
+    where
+        data = 0x13dc01dc /*promote*/
+        and to in (
+            select minipool
+            from
+                deposits
+        )
+        and success = true
+)
+
+select
+    deposits.minipool,
+    deposits.t,
+    deposits.bond_amount,
+    deposits.pubkey,
+    deposits.node_fee
+from
+    deposits
+inner join promoted on
+    deposits.minipool = promoted.minipool

--- a/rocketpool/validator/minipool_master.sql
+++ b/rocketpool/validator/minipool_master.sql
@@ -7,6 +7,10 @@ select
     deposits.deposit_type,
     deposits.bond_amount as orig_bond_amount,
     deposits.node_fee as orig_node_fee,
+    queue.enqueued_t,
+    queue.dequeued_t,
+    queue.queue_days,
+    queue.queue_hrs,
     beacon_dep.beacon_amount_deposited,
     pubkey.pubkey,
     pubkey.validator_index,
@@ -30,3 +34,5 @@ left join query_4125574 as beacon_wth /* minipool_beacon_withdrawals */
     on deposits.minipool = beacon_wth.minipool
 left join query_4125568 as dist /* minipool_beacon_withdrawals */
     on minipool.minipool = dist.minipool
+left join query_4459261 as queue /* minipool_queue */
+    on minipool.minipool = queue.minipool

--- a/rocketpool/validator/minipool_master.sql
+++ b/rocketpool/validator/minipool_master.sql
@@ -1,3 +1,4 @@
+/* Dune query number  - 4125671 */
 select
     minipool.minipool,
     minipool.created_t,

--- a/rocketpool/validator/minipool_master.sql
+++ b/rocketpool/validator/minipool_master.sql
@@ -1,0 +1,31 @@
+select
+    minipool.minipool,
+    minipool.created_t,
+    minipool.destroyed_t,
+    minipool.node_address,
+    deposits.deposit_type,
+    deposits.bond_amount as orig_bond_amount,
+    deposits.node_fee as orig_node_fee,
+    beacon_dep.beacon_amount_deposited,
+    pubkey.pubkey,
+    pubkey.validator_index,
+    coalesce(reductions.new_bond_amount, deposits.bond_amount) as bond_amount,
+    coalesce(reductions.new_node_fee, deposits.node_fee) as node_fee,
+    reductions.new_bond_amount is not null as bond_reduced,
+    beacon_wth.exited,
+    beacon_wth.beacon_amount_withdrawn,
+    beacon_wth.beacon_amount_skim_withdrawn,
+    coalesce(dist.is_distributed, false) as is_distributed
+from query_4108319 as minipool /*minipool_created*/
+left join query_4250058 as deposits/*minipool_deposits*/
+    on minipool.minipool = deposits.minipool
+left join query_4118925 as reductions /* minipool_bond_reductions */
+    on minipool.minipool = reductions.minipool
+left join query_4250134 as pubkey /* minipool_pubkey_index */
+    on minipool.minipool = pubkey.minipool
+left join query_4119023 as beacon_dep /* minipool_beacon_deposits */
+    on pubkey.pubkey = beacon_dep.pubkey
+left join query_4125574 as beacon_wth /* minipool_beacon_withdrawals */
+    on deposits.minipool = beacon_wth.minipool
+left join query_4125568 as dist /* minipool_beacon_withdrawals */
+    on minipool.minipool = dist.minipool

--- a/rocketpool/validator/minipool_pubkey_index.sql
+++ b/rocketpool/validator/minipool_pubkey_index.sql
@@ -1,0 +1,37 @@
+/* Dune query number  - 4125574 */
+with
+pub_key as (
+    select
+        minipool,
+        pubkey,
+        validator_index
+    from
+        query_4250134 --minipool_pubkey_index
+),
+
+withdrawals as (
+    select
+        wth.block_time as t,
+        pky.validator_index,
+        wth.amount / 1e9 as amount,
+        pky.minipool,
+        pky.pubkey
+    from
+        pub_key as pky
+    inner join ethereum.withdrawals as wth
+        on pky.validator_index = wth.validator_index
+)
+
+select
+    minipool,
+    validator_index,
+    pubkey,
+    sum(amount) as beacon_amount_withdrawn,
+    sum(if(amount < 8, amount, 0)) as beacon_amount_skim_withdrawn,
+    bool_or(amount > 8) as exited
+from
+    withdrawals
+group by
+    1,
+    2,
+    3

--- a/rocketpool/validator/minipool_pubkey_index.sql
+++ b/rocketpool/validator/minipool_pubkey_index.sql
@@ -1,37 +1,16 @@
-/* Dune query number  - 4125574 */
-with
-pub_key as (
+/* Dune query number  - 4250134 */
+with pubkey as (
     select
-        minipool,
         pubkey,
-        validator_index
-    from
-        query_4250134 --minipool_pubkey_index
-),
+        minipool
+    from query_4250058  --minipool_deposit
 
-withdrawals as (
-    select
-        wth.block_time as t,
-        pky.validator_index,
-        wth.amount / 1e9 as amount,
-        pky.minipool,
-        pky.pubkey
-    from
-        pub_key as pky
-    inner join ethereum.withdrawals as wth
-        on pky.validator_index = wth.validator_index
 )
 
 select
-    minipool,
-    validator_index,
-    pubkey,
-    sum(amount) as beacon_amount_withdrawn,
-    sum(if(amount < 8, amount, 0)) as beacon_amount_skim_withdrawn,
-    bool_or(amount > 8) as exited
+    pubkey.minipool,
+    pubkey.pubkey,
+    index.validator_index
 from
-    withdrawals
-group by
-    1,
-    2,
-    3
+    query_4278045 as index --validator_pubkey_index
+inner join pubkey on index.pubkey = pubkey.pubkey

--- a/rocketpool/validator/minipool_queue.sql
+++ b/rocketpool/validator/minipool_queue.sql
@@ -1,0 +1,42 @@
+with
+minipool as (
+    select minipool
+    from
+        query_4108319
+)
+,
+minipool_enqueued as (
+    select
+        evt_block_time as t,
+        minipool
+    from
+        rocketpool_ethereum.RocketMinipoolQueue_evt_MinipoolEnqueued
+)
+,
+minipool_dequeued as (
+    select
+        evt_block_time as t,
+        minipool
+    from
+        rocketpool_ethereum.RocketMinipoolQueue_evt_MinipoolDequeued
+)
+,
+minipool_removed as (
+    select
+        evt_block_time as t,
+        minipool
+    from
+        rocketpool_ethereum.RocketMinipoolQueue_evt_MinipoolRemoved
+)
+
+select
+    minipool.minipool,
+    enq.t as enqueued_t,
+    coalesce(deq.t, rem.t) as dequeued_t,
+    date_diff('day', enq.t, coalesce(deq.t, rem.t)) as queue_days,
+    date_diff('hour', enq.t, coalesce(deq.t, rem.t)) as queue_hrs
+from
+    minipool
+left join minipool_enqueued as enq on minipool.minipool = enq.minipool
+left join minipool_dequeued as deq on minipool.minipool = deq.minipool
+left join minipool_removed as rem on minipool.minipool = rem.minipool

--- a/validator/validator_pubkey_index.sql
+++ b/validator/validator_pubkey_index.sql
@@ -1,0 +1,49 @@
+/* Dune query number  - 4278045 */
+-- This query assigns a validator_index to ETH staking deposits based solely on Ethereum mainnet deposit events
+-- With no way of telling if a staking node is valid, the rare invalid ones need to be manually blacklisted
+-- To ensure this query's validity, check the latest index on https://beaconscan.com/validators and check that 
+-- the pubkey matches this query's 
+
+with failed_staking_pubkeys as (
+    select pubkey
+    from (
+        values
+        (0xb01dd8e44a8e02e36e0d66161103b9ff32315dbb9ae8c8ac8d097ba86a9e2b1eb3c7fd41e7cd1f77a987985639c26f52),
+        (0xac424d8a3e6ce38eb22109125357324a1c44ecad7a330a3d3deff91e68f4b567ba38c065d2cf852ef050d21705e5dfcb),
+        (0x918f080ca717afed4966901794ad8222ca618b523bbd3ce94be4a1240aa69d9be20f884950214a3cafa0404ce41213e1),
+        (0xa8bcbf91bff7d3368ddbf5b35c46a4f5d82b16230c851a4b8eec82be45225d339414170e14a6cd17ad83ee3792dead85),
+        (0x86f473a006c566f1648a82c74cdfbd4a3cb2ea04eb2e0d49ef381ab2562576888554ef3d39e56996f24c804abb489600),
+        (0x8c69edd7a8e8da5330787952a1ad5075516e6fd4bda1586d62dd64701f7628d5229eb7f929017dea9ae6995f9c69ef5e),
+        (0x80a29e569e8ced0be1fff42c845a59449aecf8a2503542e4e76763ccc0265e683e2d5d46618cc829349293ed08ff49ff),
+        (0xac3a0887866d5d45555904e2cb35e1b89b4c338c19001b0cc1184c9f95c5a731ccef70dc4c4fed7709c2106042a119c9),
+        (0x828116d0d2e945f1483ec7c6c135a8e00814588879e9a12a67c42268c339388b6f796f6c858e673f6000f5d028b913da),
+        (0xa03840dd6af6555442e3fc0d62de8dde77970f45175ea9926327372b5c83542f67cdd06e14e1daa44a3ae23e4d8eef52),
+        (0x8107543db1d5c69be127b3eb84c0f7b8157b892482f7e98b85b83d9a6be75e7c24a645df6283d46b16285862530cad77),
+        (0x8e05d99c557001d06f8240d46899b829a8cc77ac57b3d16359279cad707cfe5f223a3374987ab73a379ee358dd05d524),
+        (0x8d135f9185f635be5e3d738c835a02d5efab05bc5fa38ce4cb6d02156446aa3cc1ce9cc38576ec519af815dc39d52c81),
+        (0x8151e62f956cf1562007d9620fd4e91c029fb43959d1a7d1d2168c2943d65a3ef31764d1cc2d2540fb26ce86efad2ffd),
+        (0x86af099d9134b2994b835cced1fadfb4587dddfc4010470db9d8875cffd9e5a62a197db7d9c0266fb67c5175feb7ef51),
+        (0xb913a27913c8a74c05cc31c1a690ecad05a59e405bd7c5e8f6eab8e426e041a98b26cf40b04356b4d92ac20a56b7dcae),
+        (0xaebf3fbab24f55df829e2bc939bb987cbdb3edea7d4cb8877e422f1185d03a22f3a0f6449a1d6d1b912ec09ed11f2bb3),
+        (0x816827749a5194cf8389419e88d87f6786436daaa5546b92c68af015f0b7e17c66f4bb30b18872f3f051c2bc213ecaab),
+        (0xa0ab932b24d80a7a96f0fb32ce2aa724625eb090c70cb9c977f0bc5909503629155335be021e58b245e11a77c847a11c),
+        (0x9714e943c81d802f3c858f284fff25779818a903c034a3de42da7a2b63ae6632c52b2be0982007e8090d0d334f8cf656)
+    ) as temp_table (pubkey)
+)
+,
+indexes as (
+    select
+        pubkey,
+        row_number() over (order by min(deposit_index)) - 1 as validator_index
+    from staking_ethereum.deposits
+    where pubkey not in (select pubkey from failed_staking_pubkeys)
+    group by 1
+)
+
+select distinct
+    ind.validator_index,
+    dep.pubkey
+from staking_ethereum.deposits as dep
+inner join indexes as ind on dep.pubkey = ind.pubkey
+where dep.pubkey not in (select pubkey from failed_staking_pubkeys)
+order by 1 desc


### PR DESCRIPTION
These queries are intended to enable analytics related to node operators and minipools.

**Rocketpool/validator/**
- minipool_created_destroyed - Tracks minipool created event
- minipool_deposit_standard - tracks standard deposits to minipools
- minipool_deposit_credit - tracks credit deposits to minipools
- minipool_deposit_vacant - tracks deposits to vacant minipools(solo migrations)
- minipool_deposit - aggregates the deposit events above
- minipool_beacon_deposit - track beacon chain deposits
- minipool_pubkey_index - calculates the minipool indexes
- minipool_beacon_withdrawal - tracks withdrawals to minipools including exit and skim withdrawals
- minipool_balance_distributed - tracks balance distribution following minipool beacon chain withdrawal
- minipool_bond_reduction - tracks bond reduction events
- minipool_master - aggregates all minipool queries above into one master list of minipools to be used for analytics.

**rocketpool/rpl/**
-rpl_staked - tracks overall staking of RPL

**node_operator/**
-node_operators - tracks node operator registration
-node_rpl_staking - tracks node operator staking events
-node_smoothing_pool - tracks node operator smoothing pool status
-node master - aggregates all node queries above into one master list of nodes including metrics about minipools, rpl_staking, and collateral ratio

**validator/**
validator_pubkey_index - this is a calculated index number for all validators.  This is actually not tracked on chain and the existing query was not being maintained.  Invalid deposits to the beacon chain need tracked and hard coded into this query if indexes are off.

